### PR TITLE
Add feature: shift+choose to navigate to google results page

### DIFF
--- a/anycomplete.lua
+++ b/anycomplete.lua
@@ -3,18 +3,26 @@ local urlencode = require("urlencode")
 
 -- Anycomplete
 hs.hotkey.bind({"cmd", "alt", "ctrl"}, "G", function()
-    local GOOGLE_ENDPOINT = 'https://suggestqueries.google.com/complete/search?client=firefox&q=%s'
+    local GOOGLE_SUGGEST_ENDPOINT = 'https://suggestqueries.google.com/complete/search?client=firefox&q=%s'
+    local GOOGLE_SEARCH_ENDPOINT = 'https://www.google.co.uk/#q=%s'
+
     local current = hs.application.frontmostApplication()
 
     local chooser = hs.chooser.new(function(choosen)
-        current:activate()
-        hs.eventtap.keyStrokes(choosen.text)
+        if hs.eventtap.checkKeyboardModifiers()['shift'] then
+          -- holding shift as they choose so load in google instead
+          hs.execute("open " .. string.format(GOOGLE_SEARCH_ENDPOINT, choosen.text))
+        else
+          -- default behaviour: type out text to previously frontmost app
+          current:activate()
+          hs.eventtap.keyStrokes(choosen.text)
+      end
     end)
 
     chooser:queryChangedCallback(function(string)
         local query = urlencode.string(string)
 
-        hs.http.asyncGet(string.format(GOOGLE_ENDPOINT, query), nil, function(status, data)
+        hs.http.asyncGet(string.format(GOOGLE_SUGGEST_ENDPOINT, query), nil, function(status, data)
             if not data then return end
 
             local ok, results = pcall(function() return hs.json.decode(data) end)


### PR DESCRIPTION
This adds a feature: if shift is held down whilst choosing a suggested option then instead of typing out, we load the google results for that search.

Currently using google.co.uk for results.

