### PR TITLE
Debounce requests by using a timer, to avoid one request per key stroke.

### DIFF
--- a/anycomplete.lua
+++ b/anycomplete.lua
@@ -3,6 +3,7 @@
 hs.hotkey.bind({"cmd", "alt", "ctrl"}, "G", function()
     local GOOGLE_ENDPOINT = 'https://suggestqueries.google.com/complete/search?client=firefox&q=%s'
     local current = hs.application.frontmostApplication()
+    local timer;
 
     local chooser = hs.chooser.new(function(choosen)
         current:activate()
@@ -10,21 +11,30 @@ hs.hotkey.bind({"cmd", "alt", "ctrl"}, "G", function()
     end)
 
     chooser:queryChangedCallback(function(string)
-        local query = hs.http.encodeForQuery(string)
+        if timer and timer:running() then
+            timer:stop()
+        end
 
-        hs.http.asyncGet(string.format(GOOGLE_ENDPOINT, query), nil, function(status, data)
-            if not data then return end
+        timer = hs.timer.doAfter(0.3, function()
+            if not string or string == "" then return end
 
-            local ok, results = pcall(function() return hs.json.decode(data) end)
-            if not ok then return end
+            -- hs.alert.show(string)
+            local query = hs.http.encodeForQuery(string)
 
-            choices = hs.fnutils.imap(results[2], function(result)
-                return {
-                    ["text"] = result,
-                }
+            hs.http.asyncGet(string.format(GOOGLE_ENDPOINT, query), nil, function(status, data)
+                if not data then return end
+
+                local ok, results = pcall(function() return hs.json.decode(data) end)
+                if not ok then return end
+
+                choices = hs.fnutils.imap(results[2], function(result)
+                    return {
+                        ["text"] = result,
+                    }
+                end)
+
+                chooser:choices(choices)
             end)
-
-            chooser:choices(choices)
         end)
     end)
 


### PR DESCRIPTION
The current code makes one request for every keystroke, which can be too much.

This PR starts a timer (default 0.3 seconds, although that can be made customizable) and will only make the request once this timer finishes (every keystroke cancels the previous timer and starts a new one).

The diff can be hard to read because of indentation, but it basically takes all the code inside `queryChangedCallback()` and moves it inside the timer callback.

There's also a commented-out alert to display the string being sent in the request, for debugging.