### PR TITLE
Adding an installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,15 @@ The magic of Google Autocomplete while you're typing. Anywhere.
 
 ### Installation
 
-An extension for [Hammerspoon](http://hammerspoon.org/). Once Hammerspoon is installed, clone this repository to your `~/.hammerspoon` directory.
+Anycomplete is an extension for [Hammerspoon](http://hammerspoon.org/). Once Hammerspoon is installed (see [install Hammerspoon](#install-hammerspoon) below) you can run the following script to install Autocomplete.
 
-    git clone https://github.com/nathancahill/anycomplete.git ~/.hammerspoon/anycomplete
+    $ curl -sSL https://raw.githubusercontent.com/nathancahill/Anycomplete/master/install.sh | bash
+
+[install.sh](https://github.com/nathancahill/Anycomplete/blob/master/install.sh) just clones this repository into `~/.hammerspoon`, loads it into Hammerspoon and sets `⌃⌥⌘G` as the default keybinding.
+
+#### Manual installation
+
+    $ git clone https://github.com/nathancahill/anycomplete.git ~/.hammerspoon/anycomplete
 
 To initialize, add to `~/.hammerspoon/init.lua` (creating it if it does not exist):
 
@@ -20,10 +26,17 @@ you keep other Hammerspoon modules and load it appropriately.
 
 Reload the Hammerspoon config.
 
+#### Install Hammerspoon
+
+Hammerspoon can be installed using [homebrew/caskroom](https://caskroom.github.io/).
+
+    $ brew tap caskroom/cask
+    $ brew cask install hammerspoon
+    $ open -a /Applications/Hammerspoon.app
 
 ### Usage
 
-Trigger with the hotkey ⌃⌥⌘G. Once you start typing, suggestions will populate.
+Trigger with the hotkey `⌃⌥⌘G`. Once you start typing, suggestions will populate.
 They can be choosen with ⌘1-9 or by pressing the arrow keys and Enter.
 
 The hotkey can be changed by passing in arguments to

--- a/init.lua
+++ b/init.lua
@@ -1,0 +1,2 @@
+local anycomplete = require "anycomplete/anycomplete"
+anycomplete.registerDefaultBindings()

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -e
+
+HAMMER_DIR="$HOME/.hammerspoon"
+INSTALL_DIR="$HAMMER_DIR/anycomplete"
+INIT_FILE="$HAMMER_DIR/init.lua"
+
+if [ ! -d "$HAMMER_DIR" ]; then
+  echo "The directory $HAMMER_DIR doesn't exist"
+  echo "Is Hammerspoon installed?"
+  echo "You can install Hammerspoon using:"
+  echo ""
+  echo "$ brew tap caskroom/cask"
+  echo "$ brew cask install hammerspoon"
+  echo "$ open -a /Applications/Hammerspoon.app"
+  exit 1
+fi
+
+if [ -d "$INSTALL_DIR" ]; then
+  echo "Anycomplete is already installed into $INSTALL_DIR"
+  exit 1
+fi
+
+git clone https://github.com/nathancahill/Anycomplete.git "$INSTALL_DIR"
+cat "$INSTALL_DIR/init.lua" >> "$INIT_FILE"
+
+echo ""
+echo "Anycomplete has been installed into $INSTALL_DIR"
+echo "Edit $INIT_FILE to change the default keybinding"


### PR DESCRIPTION
This pull request aims to lower the usage barrier by providing an auto installer much similar to the one provided by [rvm](https://rvm.io/rvm/install) (`curl -sSL https://get.rvm.io | bash`). The `install.sh` script has been linted using [ShellCheck](https://www.shellcheck.net/).

The readme now also explains how to install Hammerspoon using `homebrew`.

Hope it can be of any usage.