### PR TITLE
README.md: remove tap from cask instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Reload the Hammerspoon config.
 
 Hammerspoon can be installed using [homebrew/caskroom](https://caskroom.github.io/).
 
-    $ brew tap caskroom/cask
     $ brew cask install hammerspoon
     $ open -a /Applications/Hammerspoon.app
 


### PR DESCRIPTION
Tapping is unnecessary. From the moment you have homebrew installed, any `brew cask` command will take care of everything for you.