### PR TITLE
update brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Reload the Hammerspoon config.
 
 Hammerspoon can be installed using [homebrew/caskroom](https://caskroom.github.io/).
 
-    $ brew cask install hammerspoon
+    $ brew install --cask hammerspoon
     $ open -a /Applications/Hammerspoon.app
 
 Accessibility must be enabled for Anycomplete to work.


### PR DESCRIPTION
brew recently disabled `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524